### PR TITLE
Add fallback web parser for Wildberries

### DIFF
--- a/lib/services/wbSimpleParser.ts
+++ b/lib/services/wbSimpleParser.ts
@@ -1,4 +1,6 @@
 // lib/services/wbSimpleParser.ts - ИСПРАВЛЕННАЯ ВЕРСИЯ
+import { WB_API_ENDPOINTS } from '../config/wbApiConfig';
+import { wbWebParser } from './wbWebParser';
 
 interface WBProductData {
   id: string;
@@ -55,6 +57,30 @@ export class WBSimpleParser {
       } catch (error) {
         console.warn(`⚠️ Метод ${index + 1} не сработал:`, error);
       }
+    }
+
+    // Попытка получить данные напрямую со страницы
+    try {
+      const webData = await wbWebParser.parseProduct(url);
+      if (webData) {
+        console.log('✅ Данные получены из веб-страницы');
+        return {
+          id: webData.id,
+          name: webData.name,
+          brand: webData.brand,
+          price: webData.price,
+          rating: 0,
+          reviewsCount: 0,
+          description: webData.description,
+          characteristics: [],
+          images: [],
+          category: 'Товары для дома',
+          availability: true,
+          vendorCode: webData.id,
+        } as WBProductData;
+      }
+    } catch (error) {
+      console.warn('⚠️ Веб парсер не сработал:', error);
     }
 
     throw new Error('Не удалось получить данные товара');
@@ -418,7 +444,7 @@ export class WBSimpleParser {
    */
   async getWBCategories(apiToken: string): Promise<any[]> {
     try {
-      const response = await fetch('https://suppliers-api.wildberries.ru/content/v2/object/all', {
+      const response = await fetch(WB_API_ENDPOINTS.getAllCategories, {
         headers: {
           'Authorization': `Bearer ${apiToken}`,
           'Content-Type': 'application/json'
@@ -449,7 +475,8 @@ export class WBSimpleParser {
    */
   async getCategoryCharacteristics(categoryId: number, apiToken: string): Promise<any[]> {
     try {
-      const response = await fetch(`https://suppliers-api.wildberries.ru/content/v2/object/charcs/${categoryId}`, {
+      const url = WB_API_ENDPOINTS.getCategoryCharacteristics(categoryId);
+      const response = await fetch(url, {
         headers: {
           'Authorization': `Bearer ${apiToken}`,
           'Content-Type': 'application/json'
@@ -475,7 +502,7 @@ export class WBSimpleParser {
     try {
       console.log('🚀 Создаем карточку товара в WB...');
 
-      const response = await fetch('https://suppliers-api.wildberries.ru/content/v2/cards/upload', {
+      const response = await fetch(WB_API_ENDPOINTS.uploadCard, {
         method: 'POST',
         headers: {
           'Authorization': `Bearer ${apiToken}`,

--- a/lib/services/wbWebParser.ts
+++ b/lib/services/wbWebParser.ts
@@ -1,0 +1,49 @@
+import { chromium } from 'playwright';
+
+/**
+ * Simple web scraper for Wildberries product pages using Playwright.
+ * This is a fallback when API calls fail due to anti-bot restrictions.
+ */
+export class WBWebParser {
+  /**
+   * Fetch product data by loading the product page in a headless browser.
+   * @param url Full URL of the Wildberries product page.
+   */
+  async parseProduct(url: string) {
+    const browser = await chromium.launch();
+    const context = await browser.newContext({
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0 Safari/537.36',
+      ignoreHTTPSErrors: true,
+    });
+    const page = await context.newPage();
+
+    try {
+      await page.goto(url, { waitUntil: 'domcontentloaded' });
+      // Wait for global state script that contains JSON data about product
+      const stateHandle = await page.waitForSelector('script#__INITIAL_STATE__', {
+        timeout: 5000,
+      });
+      const stateJson = await stateHandle.evaluate((el) => el.textContent || '');
+      const state = JSON.parse(stateJson);
+      const product = state?.product?.data || state?.productCard?.data;
+      if (!product) throw new Error('No product data in page state');
+
+      return {
+        id: product.nmId?.toString() || '',
+        name: product.nmName || product.name || '',
+        brand: product.brandName || product.brand || '',
+        price: product.salePriceU ? Math.round(product.salePriceU / 100) : 0,
+        description: product.description || '',
+      };
+    } catch (error) {
+      console.warn('Web parser failed:', error);
+      return null;
+    } finally {
+      await browser.close();
+    }
+  }
+}
+
+export const wbWebParser = new WBWebParser();
+export default wbWebParser;

--- a/src/app/api/products/[id]/publish/route.ts
+++ b/src/app/api/products/[id]/publish/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/products/[id]/publish/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient, Cabinet } from '@prisma/client';
+import { WB_API_ENDPOINTS } from '../../../../../../lib/config/wbApiConfig';
 const prisma = new PrismaClient();
 
 
@@ -236,7 +237,7 @@ async function createWBCard(cardData: WBCreateCardRequest, apiToken: string): Pr
   error?: string;
 }> {
   try {
-    const response = await fetch('https://suppliers-api.wildberries.ru/content/v2/cards/upload', {
+    const response = await fetch(WB_API_ENDPOINTS.uploadCard, {
       method: 'POST',
       headers: {
         'Authorization': apiToken,
@@ -272,7 +273,7 @@ async function createWBCard(cardData: WBCreateCardRequest, apiToken: string): Pr
 // Получение ID категории по названию
 async function getCategoryIdByName(categoryName: string): Promise<number | null> {
   try {
-    const response = await fetch('https://suppliers-api.wildberries.ru/content/v2/object/all', {
+    const response = await fetch(WB_API_ENDPOINTS.getAllCategories, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- implement `WBWebParser` using Playwright to scrape product pages
- import the new parser in `wbSimpleParser` and fall back to it when API methods fail

## Testing
- `OPENAI_API_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a018a38f88332827b563fa4ba8399